### PR TITLE
[CNAPP-24185] : BE | Public Disk access still coming up need to confirm on check 

### DIFF
--- a/plugins/azure/virtualmachines/vmDiskPublicAccess.js
+++ b/plugins/azure/virtualmachines/vmDiskPublicAccess.js
@@ -35,21 +35,22 @@ module.exports = {
             }
             for (let disk of disks.data) {
                 if (!disk.id) continue;
-
-                if (disk.networkAccessPolicy) {
-                    if (disk.networkAccessPolicy.toLowerCase() === 'allowall') {
-                        helpers.addResult(results, 2, 'Disk is publicly accessible', location, disk.id);
-                        
-                    } else if (disk.networkAccessPolicy.toLowerCase() === 'allowprivate') {
-                        helpers.addResult(results, 0, 'Disk is not publicly accessible', location, disk.id);
-                        
-                    } else {
-                        helpers.addResult(results, 0, 'Disk is not publicly or privately accessible', location, disk.id);
-                        
+                
+                if (disk.publicNetworkAccess && disk.publicNetworkAccess.toLowerCase() === 'enabled') {
+                    if (disk.networkAccessPolicy) {
+                        if (disk.networkAccessPolicy.toLowerCase() === 'allowall') {
+                            helpers.addResult(results, 2, 'Disk is publicly accessible', location, disk.id);
+                            
+                        } else if (disk.networkAccessPolicy.toLowerCase() === 'allowprivate') {
+                            helpers.addResult(results, 0, 'Disk is not publicly accessible', location, disk.id);
+                            
+                        } else {
+                            helpers.addResult(results, 0, 'Disk is not publicly or privately accessible', location, disk.id);
+                        }
                     }
+                } else {
+                    helpers.addResult(results, 0, 'Public disk access is disabled', location, disk.id);
                 }
-               
-
             }
             rcb();
         }, function() {

--- a/plugins/azure/virtualmachines/vmDiskPublicAccess.js
+++ b/plugins/azure/virtualmachines/vmDiskPublicAccess.js
@@ -36,7 +36,7 @@ module.exports = {
             for (let disk of disks.data) {
                 if (!disk.id) continue;
                 
-                if (disk.publicNetworkAccess && disk.publicNetworkAccess.toLowerCase() === 'enabled') {
+                if (!disk.publicNetworkAccess || disk.publicNetworkAccess.toLowerCase() === 'enabled') {
                     if (disk.networkAccessPolicy) {
                         if (disk.networkAccessPolicy.toLowerCase() === 'allowall') {
                             helpers.addResult(results, 2, 'Disk is publicly accessible', location, disk.id);


### PR DESCRIPTION
Used `publicNetworkAccess` as the authoritative signal for disk exposure. Previously, disks with `networkAccessPolicy=AllowAll` were flagged even when public access was disabled in Azure.